### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: sonar
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Tsingis/energy-data/security/code-scanning/10](https://github.com/Tsingis/energy-data/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. The best practice is to set `contents: read` at the workflow level, which grants read-only access to repository contents for all jobs unless overridden. This is sufficient for actions like `actions/checkout` and most scanning tools, including SonarCloud, unless they require additional permissions (which is not indicated here). The change should be made near the top of the file, after the `name:` and before `on:` or immediately after `on:`. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
